### PR TITLE
Fix incomplete cache cleanup for expired LinkedIn entries

### DIFF
--- a/server/services/cacheService.js
+++ b/server/services/cacheService.js
@@ -225,6 +225,11 @@ class CacheService {
           const cached = await dbService.getItem(key);
           if (!cached || this.isExpired(cached.lastChecked)) {
             await dbService.deleteItem(key);
+
+            // Remove corresponding entry from in-memory cache as well
+            const cleanKey = key.replace('linkedin_cache:', '');
+            this.inMemoryCache.delete(cleanKey);
+
             results.removed++;
           }
         } catch (error) {


### PR DESCRIPTION
## Summary
- remove expired LinkedIn cache entries from in-memory map when purging database cache

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68ad625c05dc8333b77f2e2da134b4ab