### PR TITLE
feat: use Product Hunt API for upvotes

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -11,6 +11,9 @@ ADMIN_PASSWORD=admin123
 GOOGLE_SHEETS_ID=your_google_sheets_id
 GOOGLE_APPLICATION_CREDENTIALS=./path/to/your/service-account.json
 
+# Product Hunt API (required for upvote counts)
+PRODUCT_HUNT_API_TOKEN=your_product_hunt_api_token
+
 # LinkedIn Enrichment (optional)
 SERPAPI_KEY=your_serpapi_key
 

--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,14 @@ AUTH_METHOD=token
 ADMIN_TOKEN=your-secure-random-token-here
 
 # =================================
+# Product Hunt API (Required for upvote counts)
+# =================================
+
+# Product Hunt API token for GraphQL requests
+# Get your token from: https://www.producthunt.com/apps
+PRODUCT_HUNT_API_TOKEN=your-product-hunt-api-token
+
+# =================================
 # LinkedIn Enrichment (Optional)
 # =================================
 

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ AUTH_TOKEN=your-secure-token-123
 # APIs
 SERPAPI_API_KEY=your_serpapi_key_here
 GOOGLE_SHEETS_ID=your_google_sheets_id
+PRODUCT_HUNT_API_TOKEN=your_product_hunt_api_token
 
 # Google Cloud (base64 encoded service account JSON)
 GOOGLE_CLOUD_CREDENTIALS=your_base64_encoded_service_account_json
@@ -152,6 +153,12 @@ npm start
    - Your app will be available at `https://your-repl-name.your-username.repl.co`
 
 ## 🔧 Configuration Guide
+
+### Setting Up Product Hunt API (Upvotes)
+
+1. Create an app at [Product Hunt Apps](https://www.producthunt.com/apps).
+2. Generate a personal API token.
+3. Add `PRODUCT_HUNT_API_TOKEN` to your environment.
 
 ### Setting Up SerpAPI (LinkedIn Search)
 


### PR DESCRIPTION
## Summary
- replace HTML scraping with Product Hunt GraphQL query for `/api/ph-upvotes`
- document `PRODUCT_HUNT_API_TOKEN` in sample env files and README

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c4146dfb6483338c141674d23957f6