### PR TITLE
Fix Product Hunt upvote display

### DIFF
--- a/client/src/components/ProductList.js
+++ b/client/src/components/ProductList.js
@@ -111,7 +111,7 @@ function ProductList({ products, selectedCategory, selectedStatus, selectedSort,
 }
 
 function ProductCard({ product, formatDate, onEnrich, onStatusChange, onSwipeComplete, isMobile, selectedStatus }) {
-  const upvotes = product.upvotes || product.phUpvotes || 'N/A';
+  const upvotes = product.upvotes ?? product.phUpvotes ?? 'N/A';
   const [isEnriching, setIsEnriching] = useState(false);
   const [enrichError, setEnrichError] = useState(null);
   const [enrichedData, setEnrichedData] = useState(product.linkedInData || null);

--- a/server/app.js
+++ b/server/app.js
@@ -173,9 +173,9 @@ app.get('/api/products', async (req, res) => {
       products = await dbService.getAllProducts();
     }
 
-    // Fetch and update upvotes for products missing them
+    // Fetch and update upvotes for products missing them or with zero votes
     for (const product of products) {
-      if ((product.upvotes === undefined || product.upvotes === null) && (product.phLink || product.productHuntLink)) {
+      if ((product.upvotes === undefined || product.upvotes === null || product.upvotes === 0) && (product.phLink || product.productHuntLink)) {
         try {
           const result = await productHuntService.fetchUpvotes(product.id, product.phLink || product.productHuntLink);
           product.upvotes = result.votesCount;


### PR DESCRIPTION
## Summary
- Always fetch Product Hunt upvotes when missing or zero
- Display upvotes even when count is zero

## Testing
- `npm test` (fails: Missing script)
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c420c79d888333bfe7469d5553f88e