### PR TITLE
fix: use dynamic API base URL

### DIFF
--- a/client/src/components/MainDashboard.js
+++ b/client/src/components/MainDashboard.js
@@ -16,7 +16,11 @@ const MainDashboard = () => {
   const [selectedSort, setSelectedSort] = useState('upvotes');
   const [isMobile, setIsMobile] = useState(false);
 
-  const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:5000';
+  const API_BASE_URL =
+    import.meta.env.VITE_API_BASE_URL ||
+    (import.meta.env.MODE === 'development'
+      ? 'http://localhost:5000'
+      : window.location.origin);
   const categories = ['all', 'artificial-intelligence', 'developer-tools', 'saas'];
 
   // Check for mobile view and set default status to pending

--- a/client/src/components/ProductList.js
+++ b/client/src/components/ProductList.js
@@ -119,7 +119,11 @@ function ProductCard({ product, formatDate, onEnrich, onStatusChange, onSwipeCom
   const [swipeAction, setSwipeAction] = useState(null);
   const [isProcessing, setIsProcessing] = useState(false);
 
-  const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:5000';
+  const API_BASE_URL =
+    import.meta.env.VITE_API_BASE_URL ||
+    (import.meta.env.MODE === 'development'
+      ? 'http://localhost:5000'
+      : window.location.origin);
 
   const getCategoryDisplayName = (category) => {
     return category


### PR DESCRIPTION
## Summary
- use current host as API base URL in production
- ensure ProductList uses same dynamic API base URL

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c581d6a50c8333aa56a25116c45673