### PR TITLE
Initialize DB table at startup and improve saveProduct error handling

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -754,7 +754,13 @@ app.listen(PORT, async () => {
   console.log(`Environment: ${process.env.NODE_ENV || 'development'}`);
   console.log(`URL: http://localhost:${PORT}`);
   console.log('=================================');
-  
+
+  try {
+    await dbService.ensureProductsTable();
+  } catch (err) {
+    console.error('Database initialization failed:', err.message);
+  }
+
   await validateStartup();
   
   console.log('Available endpoints:');


### PR DESCRIPTION
## Summary
- ensure `products` table exists on startup by running `db-init.sql` when missing
- add detailed error logging and propagation in `saveProduct`
- invoke DB initialization during app boot

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run check`
- `node server/app.js` *(fails: Failed to ensure products table)*
- `curl -X POST http://localhost:3000/api/cron/fetch`
- `curl http://localhost:3000/api/products`


------
https://chatgpt.com/codex/tasks/task_e_68c58caa19c8833382dc357d1beb4dfc