### PR TITLE
Add browser-like headers to RSS parser

### DIFF
--- a/server/services/rssService.js
+++ b/server/services/rssService.js
@@ -17,6 +17,8 @@ class RSSService {
         'User-Agent':
           'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36',
         Accept: 'application/rss+xml, application/xml, text/xml',
+        'Accept-Language': 'en-US,en;q=0.9',
+        Referer: 'https://www.producthunt.com/',
       },
     });
     this.baseUrl = 'https://www.producthunt.com/feed';


### PR DESCRIPTION
## Summary
- include Accept-Language and Referer headers in RSS service to better mimic real browser requests

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c58f1be8b483339bfa6a870769fe2c