### PR TITLE
Remove schedule check from RSS cron fetch

### DIFF
--- a/server/routes/cron.js
+++ b/server/routes/cron.js
@@ -8,9 +8,8 @@ const cacheService = require('../services/cacheService');
 const phEnrichmentService = require('../services/phEnrichmentService');
 
 /**
- * POST /cron/fetch?force=true
+ * POST /cron/fetch
  * Trigger RSS feed fetching for all configured categories.
- * Set force=true to bypass the scheduled interval check.
  */
 router.post('/fetch', async (req, res) => {
   const startTime = Date.now();
@@ -20,26 +19,6 @@ router.post('/fetch', async (req, res) => {
   console.log('Timestamp:', new Date().toISOString());
 
   try {
-    const forceRun = req.query.force === 'true' || req.body?.force === true;
-    const scheduleCheck = await scheduleService.shouldJobRun(jobName);
-
-    if (!scheduleCheck.shouldRun && !forceRun) {
-      console.log(`Skipping RSS fetch: ${scheduleCheck.reason}`);
-      return res.json({
-        success: true,
-        skipped: true,
-        reason: scheduleCheck.reason,
-        schedule: scheduleCheck,
-        timestamp: new Date().toISOString(),
-      });
-    }
-
-    if (!scheduleCheck.shouldRun && forceRun) {
-      console.log(`Forcing RSS fetch despite schedule: ${scheduleCheck.reason}`);
-    } else {
-      console.log(`RSS fetch allowed: ${scheduleCheck.reason}`);
-    }
-
     const rssResults = await rssService.fetchAllCategories();
 
     console.log('=== RSS Fetch Completed ===');
@@ -111,7 +90,6 @@ router.post('/fetch', async (req, res) => {
       success: true,
       timestamp: new Date().toISOString(),
       duration: `${duration}ms`,
-      schedule: scheduleCheck,
       results: {
         rss: {
           categories: rssResults.categories,


### PR DESCRIPTION
## Summary
- Always fetch RSS products when /cron/fetch is called
- Remove schedule-based skip logic and force parameter

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c593a549cc8333a127d0abf78635cc