### PR TITLE
Add configurable rate limiting middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,10 @@ GOOGLE_CLOUD_CREDENTIALS=your_base64_encoded_service_account_json
 # Server Configuration
 NODE_ENV=development
 PORT=5000
+RATE_LIMIT=100
 ```
+
+`RATE_LIMIT` sets the maximum number of requests per minute (default: 100).
 
 4. **Start the development servers**
 

--- a/server/app.js
+++ b/server/app.js
@@ -2,6 +2,7 @@ const express = require('express');
 const path = require('path');
 const cors = require('cors');
 const helmet = require('helmet');
+const rateLimit = require('express-rate-limit');
 require('dotenv').config();
 const fetch = require('node-fetch');
 
@@ -20,6 +21,7 @@ const { auth, logAuthAttempt } = require('./middleware/auth');
 
 const app = express();
 const PORT = process.env.PORT || 5000;
+const RATE_LIMIT = parseInt(process.env.RATE_LIMIT || '100', 10);
 
 // Security middleware
 app.use(helmet({
@@ -48,6 +50,9 @@ if (process.env.NODE_ENV === 'production') {
   app.use(express.static(clientBuildPath));
   console.log(`Serving static files from: ${clientBuildPath}`);
 }
+
+// Rate limiting
+app.use(rateLimit({ windowMs: 60_000, max: RATE_LIMIT }));
 
 // API Routes
 app.use('/api/cron', cronRoutes);


### PR DESCRIPTION
## Summary
- add express-rate-limit to server and configure via RATE_LIMIT env var
- document RATE_LIMIT usage in README

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c5973bdfa48333917ed260573a72e5