### PR TITLE
fix: trust proxy for rate limiter

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -23,6 +23,12 @@ const app = express();
 const PORT = process.env.PORT || 5000;
 const RATE_LIMIT = parseInt(process.env.RATE_LIMIT || '100', 10);
 
+// Trust the first proxy so that rate limiting and other middleware can
+// accurately obtain the client's IP from the X-Forwarded-For header.
+// This prevents express-rate-limit from throwing an ERR_ERL_UNEXPECTED_X_FORWARDED_FOR error
+// in environments (like Replit or other proxies) that set this header.
+app.set('trust proxy', 1);
+
 // Security middleware
 app.use(helmet({
   contentSecurityPolicy: false,


### PR DESCRIPTION
## Summary
- trust first proxy so express-rate-limit can read X-Forwarded-For without errors

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c81bce5ee88333a0dfdd5a20d61816